### PR TITLE
Add calcularMensual helper and tests

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -63,7 +63,7 @@ h3 {
   border-radius: 0 !important;
 }
 .accordion-button {
-  background-color: #1A1A1A !important; /* Rojo Bootstrap danger */
+  background-color: #1A1A1A !important; /* Negro institucional */
   color: white;
   font-weight: bold;
 }

--- a/static/index.html
+++ b/static/index.html
@@ -27,6 +27,9 @@
     <!-- Bootstrap JS BUNDLE (incluye Popper) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
 
+    <!-- Utilidades -->
+    <script src="/static/js/calcularMensual.js"></script>
+
     <!--JS principal (después del bundle) -->
     <script src="/static/js/main.js"></script>
   </body>

--- a/static/js/calcularMensual.js
+++ b/static/js/calcularMensual.js
@@ -1,0 +1,17 @@
+function calcularMensual(tipo, anual) {
+  switch (tipo) {
+    case "sueldos":
+    case "pensiones":
+      return anual / 12;
+    case "honorarios":
+      return (anual / 12) * 0.8; // descuento 20%
+    default:
+      return anual / 12;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { calcularMensual };
+} else {
+  window.calcularMensual = calcularMensual;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -18,9 +18,7 @@ function inicializarDatosPersonales() {
   });
 }
 
-// ... (todo tu JS de UI, acordiones y helpers existente) ...
-
-let contadorFamiliares = 1;
+// ... (todo tu JS de UI, acordeones y helpers existente) ...
 
 function agregarFamiliar() {
   const acordeonSalud = document.createElement("div");
@@ -356,19 +354,6 @@ function initTooltipsDelegados() {
     localStorage.setItem(key, JSON.stringify(lista));
 
     mostrarIngresos();
-  }
-
-  function calcularMensual(tipo, anual) {
-    switch (tipo) {
-      case "sueldos":
-        return anual / 12;
-      case "pensiones":
-        return anual / 12;
-      case "honorarios":
-        return (anual / 12) * 0.8; // descuento 20%
-      default:
-        return anual / 12;
-    }
   }
 
   function mostrarIngresos() {

--- a/tests/calcularMensual.test.js
+++ b/tests/calcularMensual.test.js
@@ -1,0 +1,19 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { calcularMensual } = require('../static/js/calcularMensual.js');
+
+test('calcula mensual para sueldos', () => {
+  assert.equal(calcularMensual('sueldos', 12000), 1000);
+});
+
+test('calcula mensual para pensiones', () => {
+  assert.equal(calcularMensual('pensiones', 24000), 2000);
+});
+
+test('calcula mensual para honorarios aplica descuento', () => {
+  assert.equal(calcularMensual('honorarios', 12000), 800);
+});
+
+test('calcula mensual default divide por 12', () => {
+  assert.equal(calcularMensual('otros', 6000), 500);
+});


### PR DESCRIPTION
## Summary
- Corrige comentario de acordeones y elimina contador duplicado
- Documenta color negro institucional en los estilos
- Expone `calcularMensual` en un módulo reutilizable y lo cubre con pruebas

## Testing
- `node --test tests/calcularMensual.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b62563068483329e6c92f04b1e7a02